### PR TITLE
Add support for manipulating bolt: URIs

### DIFF
--- a/lib/URI/bolt.pm
+++ b/lib/URI/bolt.pm
@@ -1,0 +1,10 @@
+package URI::bolt;
+ 
+require URI::_server;
+@ISA=qw(URI::_server);
+ 
+use strict;
+ 
+sub default_port { 7687 }
+ 
+1;


### PR DESCRIPTION
Hi Mark,

[Neo4j::Driver](https://github.com/johannessen/neo4j-driver-perl) uses the [URI](https://metacpan.org/pod/URI#SERVER-METHODS) module for establishing a server connection. The easiest way to add support for `bolt:` URIs is a simple new module named `URI::bolt`.

Providing `URI::bolt` with Neo4j::Bolt seems to make sense. I _could_ add it to Neo4j::Driver, but perhaps other Neo4j::Bolt clients would like [URI](https://metacpan.org/pod/URI#SERVER-METHODS) support as well, and they might not wish to require Neo4j::Driver.

Note that this PR does not introduce any new dependency to Neo4j::Bolt. It isn't necessary to `use URI::bolt;` in any way – it just has to be somewhere in `@INC` at the time `URI->new` is called with a `bolt:` URI. The [URI](https://metacpan.org/pod/URI#CONSTRUCTORS) module will then load `URI::bolt` automatically.

Thanks in advance!
Arne