### PR TITLE
More precise representation of Cypher structural types

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
 Revision history for Perl module Neo4j::Bolt
 0.1 2019-01-09
     - First release to CPAN
+
+0.02 2020-02-06
+    - Represent Cypher structural types as blessed objects in Perl
+
+0.01 2019-02-26
+    - Initial version: regular API done, error handling, result stats

--- a/lib/Neo4j/Bolt.pm
+++ b/lib/Neo4j/Bolt.pm
@@ -1,7 +1,7 @@
 package Neo4j::Bolt;
 
 BEGIN {
-  our $VERSION = "0.01";
+  our $VERSION = "0.02";
   eval 'require Neo4j::Bolt::Config; 1';
 #  print $Neo4j::Bolt::Config::extl,"<\n";
 }
@@ -117,24 +117,30 @@ references. These represent Neo4j types according to the following:
  Bytes            scalar
  List             arrayref
  Map              hashref
- Node             hashref
- Relationship     hashref
- Path             arrayref of hashrefs
+ Node             hashref  (Neo4j::Bolt::Node)
+ Relationship     hashref  (Neo4j::Bolt::Relationship)
+ Path             arrayref (Neo4j::Bolt::Path)
 
-Nodes, Relationships and Paths are represented in L<REST::Neo4p> "as_simple()"
+Nodes, Relationships and Paths are represented in the following
 formats:
 
- Node:
- { _node => $node_id, _labels => [ $label1, $label2, ...],
-   prop1 => $value1, prop2 => $value2, ...}
+ # Node:
+ bless {
+   id => $node_id,  labels => [$label1, $label2, ...],
+   properties => {prop1 => $value1, prop2 => $value2, ...}
+ }, 'Neo4j::Bolt::Node'
 
- Relationship:
- { _relationship => $reln_id, 
-   _start => $start_node_id, _end => $end_node_id,
-   prop1 => $value1, prop2 => $value2, ...}
+ # Relationship:
+ bless {
+   id => $reln_id,  type => $reln_type,
+   start => $start_node_id,  end => $end_node_id,
+   properties => {prop1 => $value1, prop2 => $value2, ...}
+ }, 'Neo4j::Bolt::Relationship'
 
- Path:
- [ $node1, $reln12, $node2, $reln23, $node3,...]
+ # Path:
+ bless [
+   $node1, $reln12, $node2, $reln23, $node3, ...
+ ], 'Neo4j::Bolt::Path'
 
 =head1 METHODS
 

--- a/lib/Neo4j/Bolt/Cxn.pm
+++ b/lib/Neo4j/Bolt/Cxn.pm
@@ -1,6 +1,6 @@
 package Neo4j::Bolt::Cxn;
 BEGIN {
-  our $VERSION = "0.01";
+  our $VERSION = "0.02";
   require Neo4j::Bolt::TypeHandlersC;
   eval 'require Neo4j::Bolt::Config; 1';
 }

--- a/lib/Neo4j/Bolt/NeoValue.pm
+++ b/lib/Neo4j/Bolt/NeoValue.pm
@@ -2,7 +2,7 @@ package Neo4j::Bolt::NeoValue;
 #use lib '../lib';
 #use lib '../../lib';
 BEGIN {
-  our $VERSION = "0.01";
+  our $VERSION = "0.02";
   require Neo4j::Bolt::TypeHandlersC;
   eval 'require Neo4j::Bolt::Config; 1';
 }

--- a/lib/Neo4j/Bolt/ResultStream.pm
+++ b/lib/Neo4j/Bolt/ResultStream.pm
@@ -1,6 +1,6 @@
 package Neo4j::Bolt::ResultStream;
 BEGIN {
-  our $VERSION = "0.01";
+  our $VERSION = "0.02";
   require Neo4j::Bolt::Cxn;
   eval 'require Neo4j::Bolt::Config; 1';
 }

--- a/lib/Neo4j/Bolt/TypeHandlersC.pm
+++ b/lib/Neo4j/Bolt/TypeHandlersC.pm
@@ -1,6 +1,6 @@
 package Neo4j::Bolt::TypeHandlersC;
 BEGIN {
-  our $VERSION = "0.01";
+  our $VERSION = "0.02";
   eval 'require Neo4j::Bolt::Config; 1';
 }
 use JSON::PP; # operator overloading for boolean values


### PR DESCRIPTION
Initially, Neo4j::Bolt used the [REST::Neo4p](https://metacpan.org/release/REST-Neo4p) `as_simple()` formats for the representation of [Cypher structural types](https://neo4j.com/docs/cypher-manual/current/syntax/values/#structural-types) (Node, Relationship, Path). As a result, in certain cases it isn’t possible to determine whether a data structure returned from Neo4j should be represented as a structural type or as a [composite type](https://neo4j.com/docs/cypher-manual/current/syntax/values/#composite-types) (List, Map).

Examples are given in #5, #11, #17.

To address these issues, this PR proposes to instead represent structural types as follows:

**Node:**
````perl
bless {
  id => $node_id,  labels => [$label1, $label2, ...],
  properties => {prop1 => $value1, prop2 => $value2, ...}
}, 'Neo4j::Bolt::Node'
````

**Relationship:**
````perl
bless {
  id => $reln_id,  type => $reln_type,
  start => $start_node_id,  end => $end_node_id,
  properties => {prop1 => $value1, prop2 => $value2, ...}
}, 'Neo4j::Bolt::Relationship'
````

**Path:**
````perl
bless [
  $node1, $reln12, $node2, $reln23, $node3, ...
], 'Neo4j::Bolt::Path'
````

* * *

`bless` by itself is quite cheap. Storing properties in a hash of its own does have a little memory overhead, but that’s pretty much unavoidable if we want to fix #5.

The blessing is important so that structural and composite types can be distinguished from each other (#11, #17). While it isn’t necessary to implement any methods in the new packages, I suppose it wouldn’t hurt to offer an `as_simple()` method that produces the old format.