### PR TITLE
Add as_simple() method

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -17,6 +17,7 @@ t/001_useok.t
 t/002_types.t
 t/003_stream.t
 t/004_query.t
+t/006_as_simple.t
 t/098_pod.t
 t/BoltFile.pm
 META.yml

--- a/lib/Neo4j/Bolt/Node.pm
+++ b/lib/Neo4j/Bolt/Node.pm
@@ -3,6 +3,18 @@ package Neo4j::Bolt::Node;
 
 $Neo4j::Bolt::Node::VERSION = '0.02';
 
+use strict;
+use warnings;
+
+sub as_simple {
+  my ($self) = @_;
+  
+  my %simple = defined $self->{properties} ? %{$self->{properties}} : ();
+  $simple{_node} = $self->{id};
+  $simple{_labels} = defined $self->{labels} ? $self->{labels} : [];
+  return \%simple;
+}
+
 1;
 
 __END__
@@ -24,6 +36,8 @@ Neo4j::Bolt::Node - Representation of a Neo4j Node
  
  $value1 = $node->{properties}->{property1};
  $value2 = $node->{properties}->{property2};
+ 
+ $hashref = $node->as_simple;
 
 =head1 DESCRIPTION
 
@@ -34,6 +48,26 @@ synopsis above.
 
 If a query returns the same node twice, two separate
 L<Neo4j::Bolt::Node> instances will be created.
+
+=head1 METHODS
+
+=over
+
+=item as_simple()
+
+ $simple  = $node->as_simple;
+ 
+ $node_id = $simple->{_node};
+ @labels  = @{ $simple->{_labels} };
+ $value1  = $simple->{property1};
+ $value2  = $simple->{property2};
+
+Get node as a simple hashref in the style of L<REST::Neo4p>.
+
+The value of properties named C<_node> or C<_labels> will be
+replaced with the node's metadata.
+
+=back
 
 =head1 SEE ALSO
 

--- a/lib/Neo4j/Bolt/Path.pm
+++ b/lib/Neo4j/Bolt/Path.pm
@@ -3,6 +3,15 @@ package Neo4j::Bolt::Path;
 
 $Neo4j::Bolt::Relationship::VERSION = '0.02';
 
+use strict;
+use warnings;
+
+sub as_simple {
+  my ($self) = @_;
+  
+  return [ @$self ];
+}
+
 1;
 
 __END__
@@ -24,6 +33,8 @@ Neo4j::Bolt::Path - Representation of a Neo4j Path
  $start_node = $path[0];
  $end_node   = $path[@$path - 1];
  $length     = @$path >> 1;  # number of relationships
+ 
+ $arrayref = $path->as_simple;
 
 =head1 DESCRIPTION
 
@@ -34,6 +45,21 @@ as shown in the synopsis above.
 
 If a query returns the same path twice, two separate
 L<Neo4j::Bolt::Path> instances will be created.
+
+=head1 METHODS
+
+=over
+
+=item as_simple()
+
+ $simple  = $path->as_simple;
+
+Get path as a simple arrayref in the style of L<REST::Neo4p>.
+
+The simple arrayref is unblessed, but is otherwise an exact duplicate
+of the L<Neo4j::Bolt::Path> instance.
+
+=back
 
 =head1 SEE ALSO
 

--- a/lib/Neo4j/Bolt/Relationship.pm
+++ b/lib/Neo4j/Bolt/Relationship.pm
@@ -3,6 +3,20 @@ package Neo4j::Bolt::Relationship;
 
 $Neo4j::Bolt::Relationship::VERSION = '0.02';
 
+use strict;
+use warnings;
+
+sub as_simple {
+  my ($self) = @_;
+  
+  my %simple = defined $self->{properties} ? %{$self->{properties}} : ();
+  $simple{_relationship} = $self->{id};
+  $simple{_start} = $self->{start};
+  $simple{_end} = $self->{end};
+  $simple{_type} = $self->{type};
+  return \%simple;
+}
+
 1;
 
 __END__
@@ -25,6 +39,8 @@ Neo4j::Bolt::Relationship - Representation of a Neo4j Relationship
  
  $value1 = $reln->{properties}->{property1};
  $value2 = $reln->{properties}->{property2};
+ 
+ $hashref = $reln->as_simple;
 
 =head1 DESCRIPTION
 
@@ -35,6 +51,28 @@ synopsis above.
 
 If a query returns the same relationship twice, two separate
 L<Neo4j::Bolt::Relationship> instances will be created.
+
+=head1 METHODS
+
+=over
+
+=item as_simple()
+
+ $simple = $reln->as_simple;
+ 
+ $reln_id       = $simple->{_relationship};
+ $reln_type     = $simple->{_type};
+ $start_node_id = $simple->{_start};
+ $end_node_id   = $simple->{_end};
+ $value1        = $simple->{property1};
+ $value2        = $simple->{property2};
+
+Get relationship as a simple hashref in the style of L<REST::Neo4p>.
+
+The value of properties named C<_relationship>, C<_type>, C<_start>
+or C<_end> will be replaced with the relationship's metadata.
+
+=back
 
 =head1 SEE ALSO
 

--- a/lib/Neo4j/Bolt/TypeHandlersC.pm
+++ b/lib/Neo4j/Bolt/TypeHandlersC.pm
@@ -4,6 +4,10 @@ BEGIN {
   eval 'require Neo4j::Bolt::Config; 1';
 }
 use JSON::PP; # operator overloading for boolean values
+use Neo4j::Bolt::Node;
+use Neo4j::Bolt::Relationship;
+use Neo4j::Bolt::Path;
+
 use Inline 'global';
 use Inline C => Config =>
   LIBS => $Neo4j::Bolt::Config::extl,

--- a/t/006_as_simple.t
+++ b/t/006_as_simple.t
@@ -1,0 +1,25 @@
+use Test::More;
+use Neo4j::Bolt::NeoValue;
+
+$n1 = bless { id => 236874, labels => ["La", "bels"] }, "Neo4j::Bolt::Node";
+$s = { _node => 236874, _labels => ["La", "bels"] };
+is_deeply $n1->as_simple(), $s, "simple node, no props";
+
+$n2 = bless { id => 236875, properties => {prop => 42} }, "Neo4j::Bolt::Node";
+$s = { _node => 236875, _labels => [], prop => 42 };
+is_deeply $n2->as_simple(), $s, "simple node, no labels";
+
+$r1 = bless { id => 15534, start => 236874, end => 236875, type => "EDGE", properties => {prop => 17} }, "Neo4j::Bolt::Relationship";
+$s = { _relationship => 15534, _start => 236874, _end => 236875, _type => "EDGE", prop => 17 };
+is_deeply $r1->as_simple(), $s, "simple rel, with props";
+
+$v = bless { id => 0, start => 0, end => 1, type => "" }, "Neo4j::Bolt::Relationship";
+$s = { _relationship => 0, _start => 0, _end => 1, _type => "" };
+is_deeply $v->as_simple(), $s, "simple rel, no props";
+
+$v = bless [$n1, $r1, $n2], "Neo4j::Bolt::Path";
+$s = [$n1, $r1, $n2];
+is_deeply $v->as_simple(), $s, "simple path";
+
+
+done_testing;


### PR DESCRIPTION
It’s simple to add an `->as_simple()` method to the new type packages.

But *not* adding it might be even simpler.

What do you think?