### PR TITLE
Add option to set timeout (resolves #22)

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,4 +1,5 @@
 use lib '.';
+use File::Spec;
 use Builder;
 use ExtUtils::CChecker;
 use Try::Tiny;
@@ -36,6 +37,7 @@ my $build = Builder->new(
   license => 'Apache_2_0',
   # inline_modules is a property added in the subclass 'Builder.pm'
   inline_modules => [
+
     # note: the commented modules get built automatically as require'd deps
     # all can be uncommented, but Inline will redundantly compile, build, and
     # erase them from blib/lib/auto...
@@ -53,6 +55,7 @@ $build->add_to_cleanup("lib/Neo4j/Bolt/Config.pm");
 # look for libneo4j-client
 $cc->push_extra_linker_flags(split(/\s+/, $ENV{LDFLAGS}),'-lneo4j-client');
 $cc->push_extra_compiler_flags(split(/\s+/, $ENV{CFLAGS}));
+$cc->push_extra_compiler_flags('-I'.File::Spec->rel2abs('./lib/Neo4j'));
 #open my $errh, '>&STDERR';
 #open STDERR, '>/tmp/xxx_try_bolt_compile_run';
 unless (

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,6 +4,7 @@ MANIFEST
 Changes
 LICENSE
 README
+lib/Neo4j/neo4j_config_struct.h
 lib/Neo4j/Bolt.pm
 lib/Neo4j/Bolt/NeoValue.pm
 lib/Neo4j/Bolt/Cxn.pm

--- a/lib/Neo4j/Bolt.pm
+++ b/lib/Neo4j/Bolt.pm
@@ -12,46 +12,10 @@ use Inline
   name => __PACKAGE__;
 
 use Inline C => <<'END_BOLT_C';
+#include <neo4j_config_struct.h>
 #include <neo4j-client.h>
 #define CXNCLASS "Neo4j::Bolt::Cxn"
 #define BUFLEN 100
-
-struct neo4j_config
-{
-  struct neo4j_logger_provider *logger_provider;
-  struct neo4j_connection_factory *connection_factory;
-  struct neo4j_memory_allocator *allocator;
-  unsigned int mpool_block_size;
-  char *username;
-  char *password;
-  neo4j_basic_auth_callback_t basic_auth_callback;
-  void *basic_auth_callback_userdata;
-  const char *client_id;
-  unsigned int so_rcvbuf_size;
-  unsigned int so_sndbuf_size;
-  time_t connect_timeout;
-  size_t io_rcvbuf_size;
-  size_t io_sndbuf_size;
-  uint16_t snd_min_chunk_size;
-  uint16_t snd_max_chunk_size;
-  unsigned int session_request_queue_size;
-  unsigned int max_pipelined_requests;
-#ifdef HAVE_TLS
-  char *tls_private_key_file;
-  neo4j_password_callback_t tls_pem_pw_callback;
-  void *tls_pem_pw_callback_userdata;
-  char *tls_ca_file;
-  char *tls_ca_dir;
-#endif
-  bool trust_known;
-  char *known_hosts_file;
-  neo4j_unverified_host_callback_t unverified_host_callback;
-  void *unverified_host_callback_userdata;
-  uint_fast32_t render_flags;
-  unsigned int render_inspect_rows;
-  const struct neo4j_results_table_colors *results_table_colors;
-  const struct neo4j_plan_table_colors *plan_table_colors;
-};
 
 struct cxn_obj {
   neo4j_connection_t *connection;

--- a/lib/Neo4j/neo4j_config_struct.h
+++ b/lib/Neo4j/neo4j_config_struct.h
@@ -1,0 +1,41 @@
+#include<neo4j-client.h>
+
+// this is lifted from
+// https://github.com/cleishm/libneo4j-client/blob/master/lib/src/client_config.h
+
+struct neo4j_config
+{
+  struct neo4j_logger_provider *logger_provider;
+  struct neo4j_connection_factory *connection_factory;
+  struct neo4j_memory_allocator *allocator;
+  unsigned int mpool_block_size;
+  char *username;
+  char *password;
+  neo4j_basic_auth_callback_t basic_auth_callback;
+  void *basic_auth_callback_userdata;
+  const char *client_id;
+  unsigned int so_rcvbuf_size;
+  unsigned int so_sndbuf_size;
+  time_t connect_timeout;
+  size_t io_rcvbuf_size;
+  size_t io_sndbuf_size;
+  uint16_t snd_min_chunk_size;
+  uint16_t snd_max_chunk_size;
+  unsigned int session_request_queue_size;
+  unsigned int max_pipelined_requests;
+#ifdef HAVE_TLS
+  char *tls_private_key_file;
+  neo4j_password_callback_t tls_pem_pw_callback;
+  void *tls_pem_pw_callback_userdata;
+  char *tls_ca_file;
+  char *tls_ca_dir;
+#endif
+  bool trust_known;
+  char *known_hosts_file;
+  neo4j_unverified_host_callback_t unverified_host_callback;
+  void *unverified_host_callback_userdata;
+  uint_fast32_t render_flags;
+  unsigned int render_inspect_rows;
+  const struct neo4j_results_table_colors *results_table_colors;
+  const struct neo4j_plan_table_colors *plan_table_colors;
+};


### PR DESCRIPTION
I took a swing at the timeout.

The problem is, the `neo4j_config` struct’s definition differs based on `#ifdef` directives (see [client_config.h](https://github.com/cleishm/libneo4j-client/blob/master/lib/src/client_config.h#L23)). We can’t copy it verbatim. The “solution” I came up with is to only use half the struct’s definition, so the size is off. For this particular problem, that doesn’t really matter because the timeout’s position in the struct is before the point where the struct may start to differ.

But of course, as soon as you `sizeof()` this struct in any way, it blows up in your face.

I don’t like this much. But I don’t know another way to solve it. Do you?