### PR TITLE
Add Neo4j::Types inheritance to Node/Relationship/Path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - cat .sample.cypher | docker run -i --network=container:testneo --name cyphershell --entrypoint cypher-shell $DOCKERH/testneo/testneo:$NEO4J_VER
   
 install:
-  - for dep in JSON::PP URI ExtUtils::MakeMaker Test::Exception Pod::Usage Neo4j::Client Mozilla::CA Alien::OpenSSL ; do cpanm $dep ; done ; 
+  - for dep in JSON::PP URI ExtUtils::MakeMaker Test::Exception Pod::Usage Neo4j::Client Neo4j::Types Mozilla::CA Alien::OpenSSL ; do cpanm $dep ; done ; 
   - echo y$'\n'$'\n'$'\n'$'\n'y | perl Makefile.PL
   - make
   

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -60,6 +60,8 @@ WriteMakefile(
   PREREQ_PM => {
     'Alien::OpenSSL' => 0,
     'Neo4j::Client' => '0.46',
+    'Neo4j::Types' => '1.00',
+    'parent' => 0,  # parent was first released with perl v5.10.1
     'JSON::PP' => 0,
     'URI' => 0,
   },

--- a/lib/Neo4j/Bolt/Node.pm
+++ b/lib/Neo4j/Bolt/Node.pm
@@ -1,10 +1,12 @@
 package Neo4j::Bolt::Node;
 # ABSTRACT: Representation of Neo4j Node
 
-$Neo4j::Bolt::Node::VERSION = '0.40';
+$Neo4j::Bolt::Node::VERSION = '0.4201';
 
 use strict;
 use warnings;
+
+use parent 'Neo4j::Types::Node';
 
 sub as_simple {
   my ($self) = @_;
@@ -46,10 +48,17 @@ a Cypher query that returns nodes from a Neo4j database.
 Their properties and metadata can be accessed as shown in the
 synopsis above.
 
+This package inherits from L<Neo4j::Types::Node>, which
+offers an object-oriented interface to the node's
+properties and metadata. This is entirely optional to use.
+
 If a query returns the same node twice, two separate
 L<Neo4j::Bolt::Node> instances will be created.
 
 =head1 METHODS
+
+This package inherits all methods from L<Neo4j::Types::Node>.
+The following additional method is provided:
 
 =over
 
@@ -71,7 +80,7 @@ replaced with the node's metadata.
 
 =head1 SEE ALSO
 
-L<Neo4j::Bolt>
+L<Neo4j::Bolt>, L<Neo4j::Types::Node>
 
 =head1 AUTHOR
 
@@ -80,7 +89,7 @@ L<Neo4j::Bolt>
 
 =head1 LICENSE
 
-This software is Copyright (c) 2019-2020 by Arne Johannessen.
+This software is Copyright (c) 2019-2021 by Arne Johannessen.
 
 This is free software, licensed under:
 

--- a/lib/Neo4j/Bolt/Path.pm
+++ b/lib/Neo4j/Bolt/Path.pm
@@ -1,10 +1,12 @@
 package Neo4j::Bolt::Path;
 # ABSTRACT: Representation of Neo4j Path
 
-$Neo4j::Bolt::Path::VERSION = '0.40';
+$Neo4j::Bolt::Path::VERSION = '0.4201';
 
 use strict;
 use warnings;
+
+use parent 'Neo4j::Types::Path';
 
 sub as_simple {
   my ($self) = @_;
@@ -43,10 +45,17 @@ a Cypher query that returns paths from a Neo4j database.
 Their nodes, relationships and metadata can be accessed
 as shown in the synopsis above.
 
+This package inherits from L<Neo4j::Types::Path>, which
+offers an object-oriented interface to the paths's
+elements and metadata. This is entirely optional to use.
+
 If a query returns the same path twice, two separate
 L<Neo4j::Bolt::Path> instances will be created.
 
 =head1 METHODS
+
+This package inherits all methods from L<Neo4j::Types::Path>.
+The following additional method is provided:
 
 =over
 
@@ -63,7 +72,7 @@ of the L<Neo4j::Bolt::Path> instance.
 
 =head1 SEE ALSO
 
-L<Neo4j::Bolt>
+L<Neo4j::Bolt>, L<Neo4j::Types::Path>
 
 =head1 AUTHOR
 
@@ -72,7 +81,7 @@ L<Neo4j::Bolt>
 
 =head1 LICENSE
 
-This software is Copyright (c) 2020 by Arne Johannessen.
+This software is Copyright (c) 2020-2021 by Arne Johannessen.
 
 This is free software, licensed under:
 

--- a/lib/Neo4j/Bolt/Relationship.pm
+++ b/lib/Neo4j/Bolt/Relationship.pm
@@ -1,10 +1,12 @@
 package Neo4j::Bolt::Relationship;
 # ABSTRACT: Representation of Neo4j Relationship
 
-$Neo4j::Bolt::Relationship::VERSION = '0.40';
+$Neo4j::Bolt::Relationship::VERSION = '0.4201';
 
 use strict;
 use warnings;
+
+use parent 'Neo4j::Types::Relationship';
 
 sub as_simple {
   my ($self) = @_;
@@ -49,10 +51,17 @@ a Cypher query that returns relationships from a Neo4j database.
 Their properties and metadata can be accessed as shown in the
 synopsis above.
 
+This package inherits from L<Neo4j::Types::Relationship>, which
+offers an object-oriented interface to the relationship's
+properties and metadata. This is entirely optional to use.
+
 If a query returns the same relationship twice, two separate
 L<Neo4j::Bolt::Relationship> instances will be created.
 
 =head1 METHODS
+
+This package inherits all methods from L<Neo4j::Types::Relationship>.
+The following additional method is provided:
 
 =over
 
@@ -76,7 +85,7 @@ or C<_end> will be replaced with the relationship's metadata.
 
 =head1 SEE ALSO
 
-L<Neo4j::Bolt>
+L<Neo4j::Bolt>, L<Neo4j::Types::Relationship>
 
 =head1 AUTHOR
 
@@ -85,7 +94,7 @@ L<Neo4j::Bolt>
 
 =head1 LICENSE
 
-This software is Copyright (c) 2020 by Arne Johannessen
+This software is Copyright (c) 2020-2021 by Arne Johannessen
 
 This is free software, licensed under:
 


### PR DESCRIPTION
The [Neo4j::Types](https://metacpan.org/pod/Neo4j::Types) distribution provides methods to access the elements, properties, and metadata of [Neo4j::Bolt](https://metacpan.org/pod/Neo4j::Bolt#Return-Types) entities. For example:

````perl
# $path->isa('Neo4j::Bolt::Path')

# Using direct array/hash access:
@nodes = grep { ref 'Neo4j::Bolt::Node' } @$path;
say "Node labels: ", join " + ", @{ $nodes[1]->{labels} // [] };

# Using new methods:
@nodes = $path->nodes;
say "Node labels: ", join " + ", $nodes[1]->labels;
````

So this PR adds an OOP interface that is entirely optional to use. Nice to have I suppose.

However, my reason for this change is actually something else:

I’ve been doing some profiling of the driver in the course of implementing Jolt. While doing so, I noticed that the driver currently has significant overhead for Bolt queries that return large result records. That’s not news: I need to check all values in a record and convert them from e. g. [Neo4j::Bolt::Node](https://metacpan.org/pod/Neo4j::Bolt::Node) to [Neo4j::Driver::Type::Node](https://metacpan.org/pod/Neo4j::Driver::Type::Node). This is done by inspecting the entire record, looking at each field/column, and recursively inspecting any paths, lists and maps as well. It’s all relatively fast, because the number of values per record usually isn’t _that_ high, but it needs to be done for each and every record, which does take some time. My tests show that for large enough records, this step may easily increase the total time needed by like 100 % [sic].

The driver is still _fast,_ just not as fast as it could be.

If [Neo4j::Bolt](https://metacpan.org/pod/Neo4j::Bolt#Return-Types) and [Neo4j::Driver](https://metacpan.org/pod/Neo4j::Driver::Record#get) used a compatible type system, this conversion could be dropped entirely.

Having both inherit from [Neo4j::Types](https://metacpan.org/pod/Neo4j::Types) will eventually achieve just that.