### PR TITLE
Mention unsupported EXPLAIN / PROFILE in docs

### DIFF
--- a/lib/Neo4j/Bolt/ResultStream.md
+++ b/lib/Neo4j/Bolt/ResultStream.md
@@ -94,6 +94,14 @@ of the response as Perl arrays (not arrayrefs).
     provide the stream, and consumed\_after() is the time it took the 
     client (you) to pull them all.
 
+# LIMITATIONS
+
+The results of Cypher `EXPLAIN` or `PROFILE` queries are currently
+unsupported. If you need to access such results, consider using
+[Neo4j::Driver](https://metacpan.org/pod/Neo4j::Driver) or the interactive
+[Neo4j Browser](https://neo4j.com/docs/browser-manual/current/)
+instead of this module.
+
 # SEE ALSO
 
 [Neo4j::Bolt](/lib/Neo4j/Bolt.md), [Neo4j::Bolt::Cxn](/lib/Neo4j/Bolt/Cxn.md).

--- a/lib/Neo4j/Bolt/ResultStream.pm
+++ b/lib/Neo4j/Bolt/ResultStream.pm
@@ -139,6 +139,14 @@ client (you) to pull them all.
 
 =back
 
+=head1 LIMITATIONS
+
+The results of Cypher C<EXPLAIN> or C<PROFILE> queries are
+currently unsupported. If you need to access such results,
+consider using L<Neo4j::Driver> or the interactive
+L<Neo4j Browser|https://neo4j.com/docs/browser-manual/current/>
+instead of this module.
+
 =head1 SEE ALSO
 
 L<Neo4j::Bolt>, L<Neo4j::Bolt::Cxn>.


### PR DESCRIPTION
Documenting the lack of support for `EXPLAIN` and `PROFILE` queries would allow us to close issues #7 and #8 as “wontfix“.

What do you think?