### PR TITLE
Add pointer to CPAN for the latest release (#45)

### DIFF
--- a/lib/Neo4j/Bolt.md
+++ b/lib/Neo4j/Bolt.md
@@ -106,6 +106,11 @@ references. These represent Neo4j types according to the following:
 
     Set to `NONE` to turn off completely (the default).
 
+# INSTALLATION
+
+Visit [Neo4j::Bolt](https://metacpan.org/pod/Neo4j::Bolt) on CPAN
+for the newest released version and installation instructions.
+
 # SEE ALSO
 
 [Neo4j::Bolt::Cxn](/lib/Neo4j/Bolt/Cxn.md), [Neo4j::Bolt::ResultStream](/lib/Neo4j/Bolt/ResultStream.md).

--- a/lib/Neo4j/Bolt.pm
+++ b/lib/Neo4j/Bolt.pm
@@ -157,6 +157,11 @@ Set to C<NONE> to turn off completely (the default).
 
 =back
 
+=head1 INSTALLATION
+
+Visit L<Neo4j::Bolt|https://metacpan.org/pod/Neo4j::Bolt> on CPAN
+for the newest released version and installation instructions.
+
 =head1 SEE ALSO
 
 L<Neo4j::Bolt::Cxn>, L<Neo4j::Bolt::ResultStream>.


### PR DESCRIPTION
Looks like we’ve kind of decided to release on CPAN first, which makes sense for Perl modules I suppose. This PR closes #45 by documenting this in the readme on GitHub.

Unfortunately, the GitHub readme is currently a copy of the CPAN module documentation. So including a pointer to CPAN on GitHub also means including it on CPAN itself, which doesn’t make a lot of sense.

I’m not sure how you’d like to handle this.