### PR TITLE
Add ppport.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 **/.DS_Store
 
+/include/ppport.h

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,7 @@
 Changes
 include/ingyINLINE.h
 include/perlbolt.h
+include/ppport.h
 lib/Neo4j/Bolt.md
 lib/Neo4j/Bolt.pm
 lib/Neo4j/Bolt.xs

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,6 +30,7 @@ my $META = {
     },
     develop => {
       requires => {
+        'Devel::PPPort' => '3.59',
 	'Inline::C' => 0,  # in t/Boltfile.pm, used via xt/003_stream.t
 	#'IPC::Run' => 0,  # in t/lib/NeoCon.pm, but not actually used anywhere
       },
@@ -91,7 +92,7 @@ WriteMakefile(
   # in lddlflags):
   LDDLFLAGS => join(' ',Neo4j::Client->libs_static,$LDDLFLAGS),
   test => {TESTS => 't/*.t'},
-  clean => {FILES => "t/neo_info"},
+  clean => {FILES => "include/ppport.h t/neo_info"},
   PL_FILES => { "pod2md.PL" => [qw(
 				    lib/Neo4j/Bolt.pm
 				    lib/Neo4j/Bolt/CResultStream.pm
@@ -126,6 +127,17 @@ WriteMakefile(
   META_MERGE => $META,
     
  );
+
+sub MY::postamble {
+  # Generate ppport.h automatically (keep it out of the repository)
+  return <<"END";
+config ::
+\t\$(NOECHO) \$(PERLRUN) "-MDevel::PPPort" -E "-f 'include/ppport.h' or do { say 'Writing ppport.h'; Devel::PPPort::WriteFile('include/ppport.h')}"
+
+END
+  # To have ppport.h run a code analysis:
+  #   perl include/ppport.h --compat-version 5.012 --cplusplus lib/*/*.xs lib/*/*/*.xs
+}
 
 sub prompt_for_db {
   my %neo_info;

--- a/cpanfile
+++ b/cpanfile
@@ -31,6 +31,7 @@ on test => sub {
 };
 
 on develop => sub {
+  requires 'Devel::PPPort', '3.59';
   requires 'Inline::C';  # in t/Boltfile.pm, used via xt/003_stream.t
   #requires 'IPC::Run';  # in t/lib/NeoCon.pm, but not actually used anywhere
   recommends 'Path::Tiny';  # pod2md.PL


### PR DESCRIPTION
I think we should be using [ppport.h](https://metacpan.org/pod/Devel::PPPort). In addition to simplifying use of the Perl API, [apparently](https://blogs.perl.org/users/karl_williamson1/2020/10/why-you-should-use-ppporth-in-your-xs-code-modules.html) it also provides certain bugfixes for older Perls that might be relevant.

There doesn’t appear to be any downside, except for a size increase of the distribution tarball.

This change:

* Introduces the use of ppport.h. To avoid having to add this large autogenerated file to the repository, Makefile.PL is hacked to simply autogenerate it when needed. It will always be included in the dist tarball for users, so this is only relevant for developers.

* Replaces the discouraged API calls `av_len` and `is_ascii_string` with clearer alternatives.

This PR is for merging into the `feat-v5.0` branch, which seems like a good opportunity to introduce this. The test failures are due to what looks like libneo4j-client issues with Bolt v5 (#54) and are not caused by this PR.