### PR TITLE
Fix memory leaks

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Revision history for Perl module Neo4j::Bolt
     - Add types for date/time, duration, point, bytes
     - Support for Perl core distinguished booleans on Perl v5.36+
     - Conform to Neo4j::Types v2
+    - Fix several memory leaks (#61)
     - Update (c)
 0.4203 2021-09-09
     - Fix support for Perl v5.16, v5.14, v5.12 (#44)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -80,7 +80,7 @@ WriteMakefile(
     'Try::Tiny' => 0,
   },
   BUILD_REQUIRES => {
-    # Nothing beyond CONFIGURE_REQUIRES, so we're all set here!
+    'ExtUtils::Typemaps' => '3.24',  # embedded typemap
   },
   PREREQ_PM => {
     'Alien::OpenSSL' => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -15,6 +15,10 @@ on configure => sub {
   requires 'Try::Tiny';
 };
 
+on build => sub {
+  requires 'ExtUtils::Typemaps', '3.24';  # embedded typemap
+};
+
 on test => sub {
   requires 'Carp';
   requires 'Cwd';

--- a/lib/Neo4j/Bolt.xs
+++ b/lib/Neo4j/Bolt.xs
@@ -15,7 +15,7 @@ void new_cxn_obj(cxn_obj_t **cxn_obj) {
   (*cxn_obj)->errnum = 0;
   int major_version = 0;
   int minor_version = 0;
-  (*cxn_obj)->strerror = "";
+  (*cxn_obj)->strerror = savepvs("");
 }		 
 
 int set_log_level( const char* classname, const char* lvl )
@@ -55,7 +55,7 @@ SV* connect_ ( const char* classname, const char* neo4j_url,
   SV *cxn;
   SV *cxn_ref;
   cxn_obj_t *cxn_obj;
-  char *climsg, *s;
+  char climsg[BUFLEN];
   neo4j_config_t *config;
   new_cxn_obj(&cxn_obj);
   neo4j_client_init();
@@ -82,8 +82,8 @@ SV* connect_ ( const char* classname, const char* neo4j_url,
   if (cxn_obj->connection == NULL) {
     cxn_obj->errnum = errno;
     cxn_obj->connected = false;
-    Newx(climsg, BUFLEN, char);
-    cxn_obj->strerror = neo4j_strerror(errno, climsg, BUFLEN-1);
+    Safefree(cxn_obj->strerror);
+    cxn_obj->strerror = savepv( neo4j_strerror(errno, climsg, sizeof(climsg)) );
   } else {
     if ( encrypt && ! neo4j_connection_is_secure(cxn_obj->connection) ) {
       warn("Bolt connection not secure!");
@@ -91,7 +91,6 @@ SV* connect_ ( const char* classname, const char* neo4j_url,
     cxn_obj->major_version = cxn_obj->connection->version;
     cxn_obj->minor_version = cxn_obj->connection->minor_version;
     cxn_obj->connected = true;
-    cxn_obj->strerror = "";
   }
   cxn = newSViv((IV) cxn_obj);
   cxn_ref = newRV_noinc(cxn);

--- a/lib/Neo4j/Bolt/Cxn.xs
+++ b/lib/Neo4j/Bolt/Cxn.xs
@@ -24,7 +24,8 @@ SV *run_query_( SV *cxn_ref, const char *cypher_query, SV *params_ref, int send,
   cxn_obj = C_PTR_OF(cxn_ref,cxn_obj_t);
   if (!cxn_obj->connected) {
     cxn_obj->errnum = ENOTCONN;
-    cxn_obj->strerror = "Not connected";
+    Safefree(cxn_obj->strerror);
+    cxn_obj->strerror = savepvs("Not connected");
     return &PL_sv_undef;
   }
   cxn = cxn_obj->connection;
@@ -76,14 +77,14 @@ const char *errmsg_(SV *cxn_ref) {
 void reset_ (SV *cxn_ref)
 {
   int rc;
-  char *climsg;
+  char climsg[BUFLEN];
   cxn_obj_t *cxn_obj;
   cxn_obj = C_PTR_OF(cxn_ref,cxn_obj_t);
   rc = neo4j_reset( cxn_obj->connection );
   if (rc < 0) {
     cxn_obj->errnum = errno;
-    Newx(climsg, BUFLEN, char);
-    cxn_obj->strerror = neo4j_strerror(errno, climsg, BUFLEN-1);
+    Safefree(cxn_obj->strerror);
+    cxn_obj->strerror = savepv( neo4j_strerror(errno, climsg, sizeof(climsg)) );
   }
   return;
 }
@@ -92,15 +93,12 @@ const char *server_id_(SV *cxn_ref) {
   return neo4j_server_id( C_PTR_OF(cxn_ref,cxn_obj_t)->connection );
 }
 
-const char *protocol_version_(SV *cxn_ref) {
+char *protocol_version_(SV *cxn_ref) {
     if (C_PTR_OF(cxn_ref,cxn_obj_t)->connected)
     {
 	uint32_t V = C_PTR_OF(cxn_ref,cxn_obj_t)->major_version;
 	uint32_t v = C_PTR_OF(cxn_ref,cxn_obj_t)->minor_version;
-	char *vstr;
-	Newx(vstr, 32, char);
-	snprintf(vstr, 32, "%d.%d",(int)V,(int)v);
-	return vstr;
+	return Perl_form(aTHX_ "%d.%d", (int)V, (int)v);
     }
     else {
 	return "";
@@ -111,6 +109,7 @@ void DESTROY (SV *cxn_ref)
 {
   cxn_obj_t *cxn_obj = C_PTR_OF(cxn_ref,cxn_obj_t);
   neo4j_close(cxn_obj->connection);
+  Safefree(cxn_obj->strerror);
   Safefree(cxn_obj);
   return;
 }

--- a/lib/Neo4j/Bolt/Cxn.xs
+++ b/lib/Neo4j/Bolt/Cxn.xs
@@ -109,7 +109,9 @@ const char *protocol_version_(SV *cxn_ref) {
 
 void DESTROY (SV *cxn_ref)
 {
-  neo4j_close( C_PTR_OF(cxn_ref,cxn_obj_t)->connection );
+  cxn_obj_t *cxn_obj = C_PTR_OF(cxn_ref,cxn_obj_t);
+  neo4j_close(cxn_obj->connection);
+  Safefree(cxn_obj);
   return;
 }
 

--- a/lib/Neo4j/Bolt/ResultStream.xs
+++ b/lib/Neo4j/Bolt/ResultStream.xs
@@ -47,7 +47,7 @@ void fetch_next_ (SV *rs_ref) {
   for (i=0; i<n; i++) {
     value = neo4j_result_field(result, i);
     perl_value = neo4j_value_to_SV(value);
-    Inline_Stack_Push( perl_value );
+    Inline_Stack_Push( sv_2mortal(perl_value) );
   }
   Inline_Stack_Done;
   return;
@@ -146,17 +146,17 @@ void update_counts_ (SV *rs_ref) {
   }
   uc = C_PTR_OF(rs_ref,rs_obj_t)->stats->update_counts;
 
-  Inline_Stack_Push( newSViv( (const UV) uc->nodes_created ));
-  Inline_Stack_Push( newSViv( (const UV) uc->nodes_deleted ));
-  Inline_Stack_Push( newSViv( (const UV) uc->relationships_created ));
-  Inline_Stack_Push( newSViv( (const UV) uc->relationships_deleted ));
-  Inline_Stack_Push( newSViv( (const UV) uc->properties_set ));
-  Inline_Stack_Push( newSViv( (const UV) uc->labels_added ));
-  Inline_Stack_Push( newSViv( (const UV) uc->labels_removed ));
-  Inline_Stack_Push( newSViv( (const UV) uc->indexes_added ));
-  Inline_Stack_Push( newSViv( (const UV) uc->indexes_removed ));
-  Inline_Stack_Push( newSViv( (const UV) uc->constraints_added ));
-  Inline_Stack_Push( newSViv( (const UV) uc->constraints_removed ));
+  mXPUSHu( (const UV) uc->nodes_created );
+  mXPUSHu( (const UV) uc->nodes_deleted );
+  mXPUSHu( (const UV) uc->relationships_created );
+  mXPUSHu( (const UV) uc->relationships_deleted );
+  mXPUSHu( (const UV) uc->properties_set );
+  mXPUSHu( (const UV) uc->labels_added );
+  mXPUSHu( (const UV) uc->labels_removed );
+  mXPUSHu( (const UV) uc->indexes_added );
+  mXPUSHu( (const UV) uc->indexes_removed );
+  mXPUSHu( (const UV) uc->constraints_added );
+  mXPUSHu( (const UV) uc->constraints_removed );
   Inline_Stack_Done;
   return;
 }

--- a/lib/Neo4j/Bolt/ResultStream.xs
+++ b/lib/Neo4j/Bolt/ResultStream.xs
@@ -165,6 +165,9 @@ void DESTROY (SV *rs_ref) {
   rs_obj_t *rs_obj;
   rs_obj = C_PTR_OF(rs_ref,rs_obj_t);
   neo4j_close_results(rs_obj->res_stream);
+  Safefree(rs_obj->eval_errcode);
+  Safefree(rs_obj->eval_errmsg);
+  Safefree(rs_obj->strerror);
   Safefree(rs_obj->stats->update_counts);
   Safefree(rs_obj->stats);
   Safefree(rs_obj);

--- a/lib/Neo4j/Bolt/Txn.xs
+++ b/lib/Neo4j/Bolt/Txn.xs
@@ -11,14 +11,14 @@ void new_txn_obj( txn_obj_t **txn_obj) {
   Newx(*txn_obj,1,txn_obj_t);
   (*txn_obj)->tx = NULL;
   (*txn_obj)->errnum = 0;
-  (*txn_obj)->strerror = "";
+  (*txn_obj)->strerror = savepvs("");
   return;
 }
 
 // class method
 SV *begin_( const char* classname, SV *cxn_ref, int tx_timeout, const char *mode, const char *dbname) {
   txn_obj_t *txn_obj;
-  char *climsg;
+  char climsg[BUFLEN];
   new_txn_obj(&txn_obj);
   cxn_obj_t *cxn_obj = C_PTR_OF(cxn_ref, cxn_obj_t);
   neo4j_transaction_t *tx = neo4j_begin_tx(cxn_obj->connection, tx_timeout,
@@ -27,8 +27,8 @@ SV *begin_( const char* classname, SV *cxn_ref, int tx_timeout, const char *mode
   txn_obj->tx = tx;
   if (tx == NULL) {
     txn_obj->errnum = errno;
-    Newx(climsg, BUFLEN, char);
-    txn_obj->strerror = neo4j_strerror(errno,climsg,BUFLEN);
+    Safefree(txn_obj->strerror);
+    txn_obj->strerror = savepv( neo4j_strerror(errno, climsg, sizeof(climsg)) );
   }
   SV *txn = newSViv((IV) txn_obj);
   SV *txn_ref = newRV_noinc(txn);
@@ -150,5 +150,6 @@ DESTROY (txn_obj)
         txn_obj_t *    txn_obj
     CODE:
         neo4j_free_tx(txn_obj->tx);
+        Safefree(txn_obj->strerror);
         Safefree(txn_obj);
 

--- a/lib/Neo4j/Bolt/Txn.xs
+++ b/lib/Neo4j/Bolt/Txn.xs
@@ -107,6 +107,10 @@ const char *errmsg_(SV *txn_ref) {
 
 MODULE = Neo4j::Bolt::Txn  PACKAGE = Neo4j::Bolt::Txn  
 
+TYPEMAP: <<END
+txn_obj_t *    T_PTRREF
+END
+
 PROTOTYPES: DISABLE
 
 
@@ -140,4 +144,11 @@ errnum_ (txn_ref)
 const char *
 errmsg_ (txn_ref)
 	SV *	txn_ref
+
+void
+DESTROY (txn_obj)
+        txn_obj_t *    txn_obj
+    CODE:
+        neo4j_free_tx(txn_obj->tx);
+        Safefree(txn_obj);
 


### PR DESCRIPTION
See #61 and johannessen/neo4j-driver-perl#17 for context.

The leak in query parameters https://github.com/majensen/perlbolt/issues/61#issuecomment-2451785132 isn’t addressed yet. It’ll have to wait until some time after the 0.5000 release.